### PR TITLE
96-Replace-noisyMethods-by-predefineMethods

### DIFF
--- a/PowerBuilder-Parser-Visitor/PWBFamixImporter.class.st
+++ b/PowerBuilder-Parser-Visitor/PWBFamixImporter.class.st
@@ -48,7 +48,7 @@ PWBFamixImporter class >> importFromFolder: aFolder [
 { #category : #'as yet unclassified' }
 PWBFamixImporter >> createCleanFilesFrom: aFolder into: anotherFolder [
 	anotherFolder ensureCreateDirectory.
-	preprocessedMap := Dictionary new: aFolder visibleFiles size.
+	"preprocessedMap := Dictionary new: aFolder visibleFiles size."
 	aFolder visibleFiles
 		do: [ :aFile | 
 			| parser outputFile stream |
@@ -111,6 +111,7 @@ PWBFamixImporter >> folder: anObject [
 { #category : #'as yet unclassified' }
 PWBFamixImporter >> importInOnePass [
 	| library visitor |
+	preprocessedMap := Dictionary new.
 	visitor := PWBEntityCreatorFutureReferenceSolverVisitor new.
 	visitor model: self targetModel.
 	visitor importingContext: self importingContext.

--- a/PowerBuilder-Parser-Visitor/PWBImporterAbstractVisitor.class.st
+++ b/PowerBuilder-Parser-Visitor/PWBImporterAbstractVisitor.class.st
@@ -49,7 +49,7 @@ PWBImporterAbstractVisitor >> create: aClass from: anASTNode [
 { #category : #'entities creation' }
 PWBImporterAbstractVisitor >> createAssociation: aClass from: anASTNode [
 	| created |
-"	self haltIf: aClass = FamixPWBInvocation."
+	"self haltIf: aClass = FamixPWBInvocation."
 	created := self createAssociation: aClass.
 	created
 		sourceAnchor:


### PR DESCRIPTION
Preprossessing map is betraying:
Pb:  Normally the preprocessing map should hold  cleaned file positions and  the number of character remove from head.
But  createCleanFilesFrom: aFolder into: anotherFolder recreate it each time it is called.  So at the end we only have files of the last folder 
As consequence  the string mapping is wrong .